### PR TITLE
Add porting.hpp, adapt project to use porting.hpp types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(Headers
     heuristic.hpp
     MAPPGridState.hpp
     astar.hpp
+    porting.hpp
 )
 
 set(Sources

--- a/MAPPGridState.cpp
+++ b/MAPPGridState.cpp
@@ -1,6 +1,6 @@
 #include "MAPPGridState.hpp"
 
-MAPPGridState::MAPPGridState( std::vector<Agent>&agents, unsigned int xsize, unsigned int ysize, unsigned int cost )
+MAPPGridState::MAPPGridState( vector<Agent>&agents, unsigned int xsize, unsigned int ysize, unsigned int cost )
 {
     this->agents =agents;
     this->xsize  = xsize;
@@ -15,10 +15,10 @@ MAPPGridState::MAPPGridState( std::vector<Agent>&agents, unsigned int xsize, uns
     }
     currentCost = cost;
 }
-void MAPPGridState::succCoords( std::vector<Agent> &ret, const Agent &a ) const
+void MAPPGridState::succCoords( vector<Agent> &ret, const Agent &a ) const
 {  /* 
     * Take an Agent, move it right, left, up, down, and return
-    * the new std::vector of Agents. But check for border and wall
+    * the new vector of Agents. But check for border and wall
     * collisions.
     */ 
     int x = a.getX();
@@ -43,7 +43,7 @@ void MAPPGridState::succCoords( std::vector<Agent> &ret, const Agent &a ) const
     }
 }
 
-bool MAPPGridState::goodSuccessor( const std::vector<Agent> &successor )
+bool MAPPGridState::goodSuccessor( const vector<Agent> &successor )
 {
     /*
      * If the new successor is valid (no two agents are at the same coords)
@@ -67,13 +67,13 @@ bool MAPPGridState::goodSuccessor( const std::vector<Agent> &successor )
     return true;
 }
 
-std::vector<MAPPGridState> MAPPGridState::successors()
+vector<MAPPGridState> MAPPGridState::successors()
 {
     /*
-     * Return the std::vector of successor states
+     * Return the vector of successor states
      */ 
-    std::vector<Agent> newCoords[numberAgents];
-    std::vector<MAPPGridState> newStates;
+    vector<Agent> newCoords[numberAgents];
+    vector<MAPPGridState> newStates;
     
     /* There cannot be more than 4 new states (up, down, left, right) */
     newStates.reserve(4);
@@ -98,7 +98,7 @@ std::vector<MAPPGridState> MAPPGridState::successors()
             /* Make a copy of the agent whose position will be modified */
             Agent tmp    = agents.at(i);
 
-            /* Now, the agents std::vector holds the successor candidate position */
+            /* Now, the agents vector holds the successor candidate position */
             agents.at(i) = newCoords[ i ][ j ];
             
             if( goodSuccessor(agents) )
@@ -126,13 +126,13 @@ void MAPPGridState::show()const
    /* 
     * Print state information
     */ 
-    std::cout << std::endl << "--------PRINTING STATE--------" << std::endl << std::endl;
+    OUTPUT << endline << "--------PRINTING STATE--------" << endline << endline;
     for( const auto &i : agents )
     {
         i.show();
     }
-    std::cout << "G  " << currentCost <<" H: " << currentHeuristic << " F: " << 
-              this->getF() << std::endl;
+    OUTPUT << "G  " << currentCost <<" H: " << currentHeuristic << " F: " << 
+              this->getF() << endline;
 }
 bool MAPPGridState::operator ==( const MAPPGridState &a)const
 {

--- a/MAPPGridState.hpp
+++ b/MAPPGridState.hpp
@@ -1,8 +1,9 @@
 #pragma once
 #include "agent.hpp"
 #include "wall.hpp"
-#include <vector>
+#include "porting.hpp"
 
+using namespace porting;
 class MAPPGridState
 {
     /*
@@ -11,7 +12,7 @@ class MAPPGridState
     *   y size of the grid.
     */
     public:
-            MAPPGridState( std::vector<Agent>&agents, unsigned int xsize, unsigned int ysize, unsigned int cost );
+            MAPPGridState( vector<Agent>&agents, unsigned int xsize, unsigned int ysize, unsigned int cost );
             inline unsigned int getF() const
             {
                 return currentCost + currentHeuristic;
@@ -39,7 +40,7 @@ class MAPPGridState
                 return false;
             }
 
-            void succCoords( std::vector<Agent> &ret, const Agent &a ) const;
+            void succCoords( vector<Agent> &ret, const Agent &a ) const;
 
             inline bool sameCoord( const Agent &a, const Agent &b )
             {
@@ -53,19 +54,19 @@ class MAPPGridState
                 return false;
             }
 
-            bool goodSuccessor( const std::vector<Agent> &successor );
+            bool goodSuccessor( const vector<Agent> &successor );
 
-            std::vector<MAPPGridState> successors();
+            vector<MAPPGridState> successors();
 
             void show() const;
 
             bool operator ==( const MAPPGridState &a)const;
-        static std::vector<Wall>walls;
+        static vector<Wall>walls;
         
-        friend struct std::less<MAPPGridState>;
-        friend struct std::hash<MAPPGridState>;
+        friend less<MAPPGridState>;
+        friend hash<MAPPGridState>;
         private:
-        std::vector<Agent>agents;
+        vector<Agent>agents;
         unsigned int xsize, ysize, numberAgents, currentCost, currentHeuristic;
 };
 

--- a/agent.cpp
+++ b/agent.cpp
@@ -2,8 +2,8 @@
 
 void Agent::show() const
 {/* Print agent information */
-    std::cout << label << " at:(" << X << ", " << Y << ")" << " goal: (" << goalX <<
-    ", "<< goalY << ")" << " heuristic: " << getH() << std::endl;
+    OUTPUT << label << " at:(" << X << ", " << Y << ")" << " goal: (" << goalX <<
+    ", "<< goalY << ")" << " heuristic: " << getH() << endline;
 }
 
 bool Agent::operator == (const Agent &a)const

--- a/agent.hpp
+++ b/agent.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "heuristic.hpp"
-#include <string>
-#include <iostream>
+#include "porting.hpp"
+using namespace porting;
 
 class Agent
 {
@@ -12,7 +12,7 @@ class Agent
     */
 
     public:
-        Agent(int x, int y, int gx, int gy, std::string l): X(x), Y(y), 
+        Agent(int x, int y, int gx, int gy, string l): X(x), Y(y), 
                                             goalX(gx), goalY(gy), label(l){};
 
         int getX() const { return X; };
@@ -21,7 +21,7 @@ class Agent
         int getGoalX() const { return goalX; };
         int getGoalY() const { return goalY; };
 
-        std::string getLabel() const { return label; };
+        string getLabel() const { return label; };
 
         void setX(int x) { X = x; };
         void setY(int y) { Y = y; };
@@ -36,5 +36,5 @@ class Agent
     private:
         int X, Y;
         int goalX, goalY;
-        std::string label;
+        string label;
 };

--- a/astar.cpp
+++ b/astar.cpp
@@ -1,15 +1,15 @@
 #include "astar.hpp"
-std::vector<MAPPGridState> Astar::astar( MAPPGridState &grid )
+vector<MAPPGridState> Astar::astar( MAPPGridState &grid )
 {
-        std::vector<MAPPGridState> newStates = grid.successors();
+        vector<MAPPGridState> newStates = grid.successors();
 
         /* A* algo */
-        std::priority_queue<MAPPGridState, std::vector<MAPPGridState>> Q;
+        priority_queue<MAPPGridState, vector<MAPPGridState>> Q;
         Q.push( grid );
         
         MAPPGridState n = grid;
-        std::unordered_map<MAPPGridState, MAPPGridState> predecessors;
-        std::unordered_map<MAPPGridState, unsigned int> minCost;
+        unordered_map<MAPPGridState, MAPPGridState> predecessors;
+        unordered_map<MAPPGridState, unsigned int> minCost;
 
         minCost.insert({n,0});
         bool going = true;
@@ -35,12 +35,12 @@ std::vector<MAPPGridState> Astar::astar( MAPPGridState &grid )
             if( n.getH() == 0 )
             {
                 going = false;
-                std::cout<<"Found a result"<<std::endl;
+                OUTPUT<<"Found a result"<<endline;
             }
         }
         
-        /* std::vector that holds state trajectory */
-        std::vector<MAPPGridState> results;
+        /* vector that holds state trajectory */
+        vector<MAPPGridState> results;
         results.reserve(10);
 
         results.emplace_back(n);

--- a/astar.hpp
+++ b/astar.hpp
@@ -1,12 +1,12 @@
 #pragma once
 #include "MAPPGridState.hpp"
-#include <unordered_map>
-#include <queue>
+#include "porting.hpp"
 #include<algorithm>
+using namespace porting;
 
 namespace Astar
 {
-    inline unsigned int mapRetrieve(const std::unordered_map<MAPPGridState, unsigned int> &m,
+    inline unsigned int mapRetrieve(const unordered_map<MAPPGridState, unsigned int> &m,
                         const MAPPGridState &n)
     {
         if ( m.find(n) != m.end() )
@@ -18,6 +18,6 @@ namespace Astar
             return 10000;
         }
     }
-    std::vector<MAPPGridState> astar( MAPPGridState &grid );
+    vector<MAPPGridState> astar( MAPPGridState &grid );
     
 };

--- a/main.cpp
+++ b/main.cpp
@@ -1,39 +1,32 @@
 
-#include "Astar.hpp"
+#include "astar.hpp"
 #include"wall.hpp"
 #include "heuristic.hpp"
 #include"agent.hpp"
 #include "MAPPGridState.hpp"
+#include "porting.hpp"
 
-std::vector<Wall> MAPPGridState::walls = {};
+vector<Wall> MAPPGridState::walls = {};
 
 int main()
 {
     /* Create walls */
-    MAPPGridState::walls.push_back(Wall(1, 5));
-    MAPPGridState::walls.push_back(Wall(9, 6));
-    MAPPGridState::walls.push_back(Wall(0, 1));
-    MAPPGridState::walls.push_back(Wall(9, 10));
-    MAPPGridState::walls.push_back(Wall(19,13));
+    MAPPGridState::walls.push_back(Wall(0, 0));
+    MAPPGridState::walls.push_back(Wall(0, 5));
 
     Agent agent_1(0,0,  10,10,  "Agent 1");
-    Agent agent_2(5,5,  15,17,  "Agent 2");
-    Agent agent_3(3,8,  19,14,  "Agent 3");
-    Agent agent_4(15,12, 1,1,   "Agent 4");
-
-    std::vector<Agent> agents;
+    Agent agent_2(0,5,  15,17,  "Agent 2");
+    vector<Agent> agents;
 
     agents.emplace_back(agent_1);
     agents.emplace_back(agent_2);
-    agents.emplace_back(agent_3);
-    agents.emplace_back(agent_4);
 
     MAPPGridState grid( agents, 100, 100, 0 );
 
     
-    std::cout<<"↓Original state↓";
+    OUTPUT << "↓Original state↓";
     grid.show();
-    std::vector<MAPPGridState> results = Astar::astar(grid);
+    vector<MAPPGridState> results = Astar::astar(grid);
     for( auto iter = results.begin(); iter < results.end(); ++iter )
     {
         iter->show();

--- a/test/AstarTests.cpp
+++ b/test/AstarTests.cpp
@@ -3,9 +3,9 @@
 #include"../MAPPGridState.hpp"
 #include"../astar.hpp"
 #include<gtest/gtest.h>
-using namespace std;
 
-vector<Wall> MAPPGridState::walls = {};
+
+std::vector<Wall> MAPPGridState::walls = {};
 
 struct AstarTests: public ::testing::Test
 {
@@ -132,7 +132,7 @@ TEST_F(AstarTests, SUCC_COORDS_1)
 
 TEST_F(AstarTests, SUCC_COORDS_2)
 {
-    vector<Agent> agents;
+    std::vector<Agent> agents;
     agents.push_back(agent_4);
 
     MAPPGridState grid( agents, 10, 10, 5 );
@@ -140,7 +140,7 @@ TEST_F(AstarTests, SUCC_COORDS_2)
     agents.clear();
     grid.succCoords(agents, agent_4);
 
-    vector<Agent> succAgents;
+    std::vector<Agent> succAgents;
     succAgents.push_back(agent_4);
     succAgents.push_back(agent_4);
     succAgents.push_back(agent_4);
@@ -174,8 +174,8 @@ TEST_F(AstarTests, GOOD_SUCCESSOR)
     * in the successor state, it only matters that the size of the grid.agents
     * and successors are the same.
     */  
-    vector<Agent> agents;
-    vector<Agent> successors;
+    std::vector<Agent> agents;
+    std::vector<Agent> successors;
     agents.push_back(agent_1);
     agents.push_back(agent_2);
     agents.push_back(agent_3);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ set(Headers
 wall.hpp
 heuristic.hpp
 agent.hpp
+porting.hpp
 )
 add_executable(${This} ${Sources})
 


### PR DESCRIPTION
Add porting.hpp so that it will be easier to port the A* algorithm to different frameworks, such as QT.